### PR TITLE
Add link to cluster name in topic and group pages

### DIFF
--- a/src/web_server/pages/group.rs
+++ b/src/web_server/pages/group.rs
@@ -34,10 +34,11 @@ pub fn group_page(cluster_id: ClusterId, group_name: &RawStr, cache: State<Cache
         None => "Not registered".to_string(),
     };
 
+    let cluster_link = format!("/clusters/{}/", cluster_id.name());
     let content = html! {
         h3 style="margin-top: 0px" "Information"
         dl class="dl-horizontal" {
-            dt "Cluster name:" dd (cluster_id)
+            dt "Cluster name:" dd { a href=(cluster_link) (cluster_id) }
             dt "Group name: " dd (group_name)
             dt "Group state: " dd (group_state)
         }

--- a/src/web_server/pages/topic.rs
+++ b/src/web_server/pages/topic.rs
@@ -62,10 +62,12 @@ pub fn topic_page(cluster_id: ClusterId, topic_name: &RawStr, cache: State<Cache
     let metrics = cache.metrics.get(&(cluster_id.clone(), topic_name.to_string()))
         .unwrap_or_default()
         .aggregate_broker_metrics();
+
+    let cluster_link = format!("/clusters/{}/", cluster_id.name());
     let content = html! {
         h3 style="margin-top: 0px" "General information"
         dl class="dl-horizontal" {
-            dt "Cluster name " dd (cluster_id)
+            dt "Cluster name " dd { a href=(cluster_link) (cluster_id) }
             dt "Topic name " dd (topic_name)
             dt "Number of partitions " dd (partitions.len())
             dt "Number of replicas " dd (partitions[0].replicas.len())


### PR DESCRIPTION
So it's easier to navigate back and forth.

![image](https://user-images.githubusercontent.com/1556054/30511488-8d49f318-9b0c-11e7-9f35-f53e867e369f.png)
