### PR TITLE
Add key and timestamp to tailed messages

### DIFF
--- a/resources/web_server/public/my_css.css
+++ b/resources/web_server/public/my_css.css
@@ -26,6 +26,14 @@ h3 {
     padding-bottom: 3px;
     margin-top: 0px;
     margin-bottom: 0px;
+    display: flex;
+}
+
+.message-key,
+.message-ts {
+    padding-right: 5px;
+    margin-right: 5px;
+    border-right: 1px solid #eee;
 }
 
 div.topic_tailer {

--- a/resources/web_server/public/my_js.js
+++ b/resources/web_server/public/my_js.js
@@ -106,6 +106,23 @@ function error_to_graphic(cell) {
     $(cell).html(symbol);
 }
 
+function message_to_tailer_entry(msg) {
+    var ts_text;
+    if (msg["created_at"]) {
+        ts_text = (new Date(msg["created_at"])).toISOString() + " Created";
+    } else if (msg["appended_at"]) {
+        ts_text = (new Date(msg["appended_at"])).toISOString() + " Appended";
+    } else {
+        ts_text = "N/A";
+    }
+
+    var entry = $("<div>", {class: "message"});
+    entry.append($("<div>", { class: "message-key", text: msg["key"] ? msg["key"] : "N/A" }));
+    entry.append($("<div>", { class: "message-ts", text: ts_text }));
+    entry.append($("<div>", { class: "message-payload", text: msg["payload"] }));
+    return entry;
+}
+
 $(document).ready(function() {
     $('#datatable-brokers-ajax').each(function(index) {
         $(this).DataTable({
@@ -375,9 +392,7 @@ function background_tailer(cluster_id, topic_name, tailer_id) {
       messages = JSON.parse(data);
       for (var i = 0; i < messages.length; i++) {
         var message = messages[i];
-        var p = $("<p>", {class: "message"});
-        p.append(truncate(message["payload"], max_msg_length));
-        div_tailer.append(p);
+        div_tailer.append(message_to_tailer_entry(message));
       }
       if (bottom)
           scroll_to_bottom(div_tailer);

--- a/resources/web_server/public/my_js.js
+++ b/resources/web_server/public/my_js.js
@@ -376,7 +376,7 @@ function background_tailer(cluster_id, topic_name, tailer_id) {
       for (var i = 0; i < messages.length; i++) {
         var message = messages[i];
         var p = $("<p>", {class: "message"});
-        p.append(truncate(message[2], max_msg_length));
+        p.append(truncate(message["payload"], max_msg_length));
         div_tailer.append(p);
       }
       if (bottom)

--- a/src/live_consumer.rs
+++ b/src/live_consumer.rs
@@ -1,7 +1,7 @@
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer, EmptyConsumerContext};
-use rdkafka::message::Timestamp::*;
 use rdkafka::message::BorrowedMessage;
+use rdkafka::message::Timestamp::*;
 use rdkafka::Message;
 use rocket::http::RawStr;
 use rocket::State;
@@ -245,14 +245,16 @@ pub fn topic_tailer_api(
             .payload()
             .map(|bytes| String::from_utf8_lossy(bytes))
             .unwrap_or(Cow::Borrowed(""));
-        let payload =
-            if original_payload.len() > 1024 {
-                format!("{}...", original_payload.chars().take(1024).collect::<String>())
-            } else {
-                original_payload.into_owned()
-            };
+        let payload = if original_payload.len() > 1024 {
+            format!(
+                "{}...",
+                original_payload.chars().take(1024).collect::<String>()
+            )
+        } else {
+            original_payload.into_owned()
+        };
 
-        output.push(TailedMessage{
+        output.push(TailedMessage {
             partition: message.partition(),
             offset: message.offset(),
             key,

--- a/src/web_server/server.rs
+++ b/src/web_server/server.rs
@@ -127,7 +127,7 @@ pub fn run_server(executor: &ThreadPoolExecutor, cache: Cache, config: &Config) 
                 api::topic_groups,
                 api::topic_search,
                 api::topic_topology,
-                live_consumer::test_live_consumer_api,
+                live_consumer::topic_tailer_api,
             ],
         )
         .launch();


### PR DESCRIPTION
To fix https://github.com/fede1024/kafka-view/issues/13

- Use a struct to organize various information of a tailed message, rather than using a tuple, and let web ui relies on the relative positions of the fields, this is what's suggested in https://github.com/fede1024/kafka-view/issues/23
- Key and timestamp will be showed with the following format, together with a screenshot to illustrate:
```
<key>|<ts>|<payload>

<key>: "N/A" when unavailabe
<ts>: "Created" or "Appended" will be added after timestamp accroding to the topic's configuration, "N/A" when unavailabe
```
![image](https://user-images.githubusercontent.com/5914530/61958416-31c02f80-afb9-11e9-82e1-f5d3df0ae511.png)
